### PR TITLE
Correct launch.yml env vars

### DIFF
--- a/launch/shorty.yml
+++ b/launch/shorty.yml
@@ -12,6 +12,7 @@ env:
   - PG_PASSWORD
   - PG_SCHEMA
   - PG_TABLE
+  - PG_DATABASE
 resources:
   cpu: 0.2
 expose:


### PR DESCRIPTION
Added 2 env vars that are set in pillar but not in launch. I don't actually think PORT is used though..?