### PR TITLE
Fix preview of generated shortlink (now includes "go" domain)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include golang.mk
 .DEFAULT_GOAL := test # override default goal set in library makefile
 
-.PHONY: test build clean doc vendor $(PKGS)
+.PHONY: test build clean doc vendor run $(PKGS)
 SHELL := /bin/bash
 PKG := github.com/Clever/shorty
 PKGS := $(shell go list ./... | grep -v /vendor)
@@ -22,3 +22,6 @@ $(PKGS): golang-test-all-deps
 
 vendor: golang-godep-vendor-deps
 	$(call golang-godep-vendor,$(PKGS))
+
+run: build
+	bin/$(EXECUTABLE) --port 8080

--- a/static/Shortener.jsx
+++ b/static/Shortener.jsx
@@ -44,7 +44,7 @@ var Shortener = React.createClass({
       },
       type: "POST",
       success: function() {
-        newLink = this.state.protocol + "://" + "/" + slug;
+        newLink = this.state.protocol + "://" + this.state.domain + "/" + slug;
         this.refreshList();
         flash = <Alert bsStyle="success">Successfully linked URL: <a href={newLink}>{newLink}</a></Alert>
         this.setState({currentOwner: owner, flash: flash});


### PR DESCRIPTION
[Before](http://www.dropbox.com/s/cdj8inn60t3vk3g/Screenshot%202016-12-12%2011.03.38.png?dl=0):

    Successfully linked URL: http:///short

[After](https://www.dropbox.com/s/62x4zw8a2tsufc7/Screenshot%202016-12-12%2011.07.26.png?dl=0):

    Successfully linked URL: http://go/short

