### PR TITLE
Add support for auto suffixing

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,8 @@ func main() {
 	r.HandleFunc("/meta", routes.MetaHandler(*protocol, *domain)).Methods("GET")
 	r.PathPrefix("/Shortener.jsx").Handler(http.FileServer(http.Dir("./static")))
 	r.PathPrefix("/favicon.png").Handler(http.FileServer(http.Dir("./static")))
-	r.HandleFunc("/{slug}", routes.RedirectHandler(sdb, *domain)).Methods("GET")
+	r.HandleFunc("/{slug}", routes.RedirectHandler(sdb, *domain, "")).Methods("GET")
+	r.HandleFunc("/{slug}/{suffix}", routes.RedirectHandler(sdb, *domain, "/")).Methods("GET")
 	r.HandleFunc("/health/check", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "STATUS OK")
 	})

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	database "github.com/Clever/shorty/db"
@@ -72,6 +73,11 @@ func ShortenHandler(db database.ShortenBackend) func(http.ResponseWriter, *http.
 		slug := r.PostForm.Get("slug")
 		longURL := r.PostForm.Get("long_url")
 		owner := r.PostForm.Get("owner")
+
+		if strings.Contains(slug, "/") {
+			returnJSON(nil, &httpError{fmt.Sprintf("You may not create a slug with a forward slash: %s", slug), 400}, w)
+			return
+		}
 
 		for _, res := range reserved {
 			if slug == res {

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -146,9 +146,10 @@ func ListHandler(db database.ShortenBackend) func(http.ResponseWriter, *http.Req
 
 // RedirectHandler redirects users to their desired location.
 // Not accessed via Ajax, just by end users
-func RedirectHandler(db database.ShortenBackend, domain string) func(http.ResponseWriter, *http.Request) {
+func RedirectHandler(db database.ShortenBackend, domain, slugSeparator string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		slug := mux.Vars(r)["slug"]
+		suffix := mux.Vars(r)["suffix"]
 		long, err := db.GetLongURL(slug)
 		if err == database.ErrNotFound {
 			w.WriteHeader(404)
@@ -161,7 +162,7 @@ func RedirectHandler(db database.ShortenBackend, domain string) func(http.Respon
 			w.Write([]byte(err.Error()))
 			return
 		}
-		http.Redirect(w, r, long, 302)
+		http.Redirect(w, r, fmt.Sprintf("%s%s%s", long, slugSeparator, suffix), 302)
 		return
 	}
 }


### PR DESCRIPTION
This PR adds support for allowing auto-suffixing shortlinks, best illustrated with the following example:

Assume the following shortlink is set up:
`go/github` => `https://github.com/Clever`

Then, the following auto-suffixed redirect is also made possible (without adding any additional shortlinks!):
`go/github/sd2` => `https://github.com/Clever/sd2`

Verified that no existing go-links will be adversely affected (i.e. no existing go-link matches the regex `go/(.*)/(.*)`)