### PR TITLE
Add launch config alarms

### DIFF
--- a/launch/shorty.yml
+++ b/launch/shorty.yml
@@ -18,7 +18,6 @@ resources:
 expose:
 - name: http
   port: 80
-  bind: 80
   load_balancer_port: 80
   load_balancer_proto: http
   health_check:

--- a/launch/shorty.yml
+++ b/launch/shorty.yml
@@ -2,27 +2,42 @@ run:
   type: docker
 elbs:
   staging:
-    - shorty-staging
+  - shorty-staging
   production:
-    - shorty
+  - shorty
 env:
-  - PG_HOST
-  - PG_PORT
-  - PG_USER
-  - PG_PASSWORD
-  - PG_SCHEMA
-  - PG_TABLE
-  - PG_DATABASE
+- PG_HOST
+- PG_PORT
+- PG_USER
+- PG_PASSWORD
+- PG_SCHEMA
+- PG_TABLE
+- PG_DATABASE
 resources:
   cpu: 0.2
 expose:
-  - name: http
-    port: 80
-    bind: 80
-    load_balancer_port: 80
-    load_balancer_proto: http
-    health_check:
-      type: http
-      path: /health/check
+- name: http
+  port: 80
+  bind: 80
+  load_balancer_port: 80
+  load_balancer_proto: http
+  health_check:
+    type: http
+    path: /health/check
 access_scope: org-wide
 team: eng-ip
+alarms:
+- type: InternalErrorAlarm
+  severity: major
+  parameters:
+    threshold: 0.10
+  extraParameters:
+    source: Total
+    errorMinimum: 5
+- type: InternalErrorAlarm
+  severity: minor
+  parameters:
+    threshold: 0.02
+  extraParameters:
+    source: Total
+    errorMinimum: 5


### PR DESCRIPTION
Add launch config alarms for DEIP services. There are three categories of services here:
- P1 internal: 1% and 5% with source:total for minor and major alarms.
- P1 external: 1% and 5% as well, but the major alarm is split into source: target and source: ELB to exclude ELB 4xxs which are expected
- P2: 2% for minor and 10% for major.
All of them errorMinimums of 5 or 10, to prevent noise when 1 out of 1 request fails.

Website is handled separately!
