### PR TITLE
[automated] Upgrade to Go 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/shorty
     docker:
-    - image: circleci/golang:1.13-stretch
+    - image: circleci/golang:1.16-stretch
     - image: circleci/postgres:9.4-alpine-ram
     - image: redis@sha256:858b1677143e9f8455821881115e276f6177221de1c663d0abef9b2fda02d065
     environment:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL := /bin/bash
 PKG := github.com/Clever/shorty
 PKGS := $(shell go list ./... | grep -v /vendor)
 EXECUTABLE := $(shell basename $(PKG))
-$(eval $(call golang-version-check,1.13))
+$(eval $(call golang-version-check,1.16))
 
 all: test build
 


### PR DESCRIPTION
This PR migrates to Go 1.16.

If the build passes, no action is required by you, infra will merge and deploy this. For any questions, reach out to @taylor-sutton (Slack `taylor`) or #oncall-infra.
