### PR TITLE
service step 1 of 4: adjust resources and deploy to pods

### DIFF
--- a/launch/shorty.yml
+++ b/launch/shorty.yml
@@ -14,7 +14,8 @@ env:
 - PG_TABLE
 - PG_DATABASE
 resources:
-  cpu: 0.2
+  cpu: 0.25
+  max_mem: 0.5
 expose:
 - name: http
   port: 80
@@ -40,3 +41,9 @@ alarms:
   extraParameters:
     source: Total
     errorMinimum: 5
+pod_config:
+  dev:
+    migrationState: deployable
+  group: org-wide
+  prod:
+    migrationState: deployable


### PR DESCRIPTION
This PR is the first step in migrating this service to pods

This PR will
- deploy to pods in dev and prod
- no traffic will go to the pod deployment
- adjust cpu and memory values based on metrics for the last 7 days to fit fargate constraints

To check before merging
- region. By default infra is migrating everything to us-west-1 but if this app talks to some dbs in us-west-2 you can run the service in us-west-2 pod
- cpu and memory. just check that the values are not unreasonable. You can go to go/services to look at the history for last 7 days if in doubt

After merging this PR once the deploy is complete
1. Verify deploy was succesful and that there were no container exits. This can be done by looking at container count in grafana (go/services)
2. Optionally also run some production like workloads. `ark info -s` to get info like endpoint URL of the pod deployment.

In case of errors:
1. revert this PR
2. merge the deploy
