### PR TITLE
move to us-west-2 orgwide pod

### DIFF
--- a/launch/shorty.yml
+++ b/launch/shorty.yml
@@ -39,7 +39,7 @@ alarms:
   extraParameters:
     errorMinimum: 5
 pod_config:
-  group: org-wide
+  group: org-wide-us-west-2
 deploy_config:
   canaryInProd: false
   autoDeployEnvs:


### PR DESCRIPTION
# Jira
https://clever.atlassian.net/browse/INFRANG-6321

# Testing
We already have many apps in org-wide-us-west-2 so this should work. The original deployment will be around so deploying this won't break anything. I can test the us-west-2 deployment before moving the DNS.  